### PR TITLE
Fix typo in template parsing.

### DIFF
--- a/apis/helloworld/functions/greeting/webpack.config.ts
+++ b/apis/helloworld/functions/greeting/webpack.config.ts
@@ -51,7 +51,7 @@ interface ISamFunction {
   };
 }
 
-const { resources } = yamlParse(readFileSync(conf.templatePath, 'utf-8'));
+const { Resources: resources } = yamlParse(readFileSync(conf.templatePath, 'utf-8'));
 
 const entries = Object.values(resources)
 


### PR DESCRIPTION
My function wouldn't build because the webpack config was looking for the wrong key in the parsed YAML.