### PR TITLE
Update webpack.config.ts so that npm run build:prod works

### DIFF
--- a/apis/helloworld/functions/greeting/webpack.config.ts
+++ b/apis/helloworld/functions/greeting/webpack.config.ts
@@ -51,9 +51,9 @@ interface ISamFunction {
   };
 }
 
-const { resources } = yamlParse(readFileSync(conf.templatePath, 'utf-8'));
+const { Resources } = yamlParse(readFileSync(conf.templatePath, 'utf-8'));
 
-const entries = Object.values(resources)
+const entries = Object.values(Resources)
 
   .filter((resource: ISamFunction) => resource.Type === 'AWS::Serverless::Function')
 


### PR DESCRIPTION
Without this change, the template throws a build error:

```
const entries = Object.values(resources)
                       ^
TypeError: Cannot convert undefined or null to object
```

this is because the variable extraction from the `yamlParse` call is case-sensitive. Actual output of `yamlParse`:

```javascript
{
  AWSTemplateFormatVersion: '2010-09-09',
  Transform: 'AWS::Serverless-2016-10-31',
  Description: 'hellword-api',
  Globals: { Function: { Timeout: 60 } },
  Resources: {
    GlobalDependenciesLayer: {
      Type: 'AWS::Serverless::LayerVersion',
      Properties: [Object],
      Metadata: [Object]
    },
    GlobalApiResponsesLayer: {
      Type: 'AWS::Serverless::LayerVersion',
      Properties: [Object],
      Metadata: [Object]
    },
    GreetingFunction: { Type: 'AWS::Serverless::Function', Properties: [Object] }
  }
}
```